### PR TITLE
Fix bug: referring userId periodically before login

### DIFF
--- a/src/components/Content.vue
+++ b/src/components/Content.vue
@@ -54,9 +54,11 @@ import axios from 'axios'
 export default {
     store,
     created() {
-        setInterval(() => {
-            this.getTweets()
-        }, 3000)
+        if (this.isLogin) {
+            setInterval(() => {
+                this.getTweets()
+            }, 3000)
+        }
     },
     data: function() {
         return {


### PR DESCRIPTION
Even before login, the app starts attempting to fetch past tweets and the requests are going to fail 🐛 

<img width="366" alt="Screen Shot 2019-05-28 at 12 06 35" src="https://user-images.githubusercontent.com/124871/58448017-70647580-8141-11e9-82dd-6da9604bb383.png">
